### PR TITLE
Update dependancies to follow repo names

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,14 +1,14 @@
 ## Scripts used
 
 GetSSHFromPrivateStorage.py   
-  
+
 WriteSSHToPrivateStorage.py  
 deploy-back.sh  
 deploy-front.sh	missing  
 deploy-prestashop.yml  
 deploy.sh	  
-ansible-csync2-lsyncd   
-ansible-init-raid  
+azure-dep-ansible-csync2-lsyncd   
+azure-dep-ansible-init-raid  
 hosts.example  
 install_roles.yml  
 php.ini  

--- a/scripts/deploy-prestashop.yml
+++ b/scripts/deploy-prestashop.yml
@@ -13,7 +13,7 @@
     - vars/main.yml
 
   roles:
-    - { role: ansible-init-raid }
+    - { role: azure-dep-ansible-init-raid }
 
 - hosts: front
   become: True
@@ -47,7 +47,7 @@
             recurse=yes
 
   roles:
-    - { role: ansible-csync2-lsyncd }
+    - { role: azure-dep-ansible-csync2-lsyncd }
 
 # Instalation of Mysql Cluster M/S
 - hosts: back
@@ -61,7 +61,7 @@
         mysql_replication_master: "{{ groups['master'][0] }}"
 
   roles:
-    - { role: ansible-role-mysql }
+    - { role: azure-dep-ansible-role-mysql }
 
 - hosts: front
   become: True


### PR DESCRIPTION
Woups, the ansible dependancies needed to be renamed in order to follow the repository names.